### PR TITLE
Changed codec configuration box to use 23001-8

### DIFF
--- a/VPCodecISOMediaFileFormatBinding.md
+++ b/VPCodecISOMediaFileFormatBinding.md
@@ -126,7 +126,7 @@ unless otherwise noted.
 #### Syntax
 
 ~~~~~
-class VPCodecConfigurationBox extends FullBox('vpcC', version, 0){
+class VPCodecConfigurationBox extends FullBox('vpcC', version, 1){
       VPCodecConfigurationRecord() vpcConfig;
 }
 


### PR DESCRIPTION
Changed colorSpace and transferFunction parameters defined in the codec
configuration box to matrixCoefficients and transferCharacteristics
fields defined in ISO/IEC 23001-8:2016. Changed the size and order of
the VPCodecConfigurationRecord.

This fixes #15.