### PR TITLE
clarify bitdepth/subsampling restrictions

### DIFF
--- a/VPCodecISOMediaFileFormatBinding.md
+++ b/VPCodecISOMediaFileFormatBinding.md
@@ -186,11 +186,13 @@ to the VP9 Bitstream Specification [^1].
 | 62    | Level 6.2                   |
 
 **bitDepth** is an integer that specifies the bit depth of the luma and color
-components. Valid values are 8, 10, and 12.
+components. Valid values are 8, 10, and 12. This value may be further
+constrained by the profile.
 
 **chromaSubsampling** is an integer that specifies the chroma subsampling.
-Only the values in the following table are allowed. If `matrixCoefficients` is
-0 (RGB), then chroma subsampling MUST be 3 (4:4:4).
+Only the values in the following table are allowed. This value may be further
+constrained by the profile. If `matrixCoefficients` is 0 (RGB), then chroma
+subsampling MUST be 3 (4:4:4).
 
 
 | Value | Subsampling|

--- a/VPCodecISOMediaFileFormatBinding.md
+++ b/VPCodecISOMediaFileFormatBinding.md
@@ -164,8 +164,6 @@ Version 0 is deprecated and should not be used.
 profile MUST be valid for all samples that reference this sample entry, that
 is, profile SHALL be equal to the profile used to encode the sample.
 
-**VP9 Coding Profiles** [^1]
-
 | Profile | Color Depth  | Chroma Subsampling |
 |:-------:|:------------:|:------------------:|
 | 0       | 8 bit/sample | 4:2:0              |

--- a/VPCodecISOMediaFileFormatBinding.md
+++ b/VPCodecISOMediaFileFormatBinding.md
@@ -164,6 +164,17 @@ Version 0 is deprecated and should not be used.
 profile MUST be valid for all samples that reference this sample entry, that
 is, profile SHALL be equal to the profile used to encode the sample.
 
+**VP9 Coding Profiles** [^1]
+
+| Profile | Color Depth  | Chroma Subsampling |
+|:-------:|:------------:|:------------------:|
+| 0       | 8 bit/sample | 4:2:0              |
+| 1       | 8 bit        | 4:2:2, 4:4:4       |
+| 2       | 10 or 12 bit | 4:2:0              |
+| 3       | 10 or 12 bit | 4:2:2, 4:4:4       |
+
+Note: VP8 only supports a profile value of 0.
+
 **level** is an integer that specifies a VP codec level all samples conform
 to the following table. For a description of the various levels, please refer
 to the VP9 Bitstream Specification [^1].


### PR DESCRIPTION
Add a note to indicate that the values for bitDepth and
chromaSubsampling are limited to the values supported by the profile.
